### PR TITLE
Concrete example of JUnit 5 shared classloader error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ minimallyCorrectDefaults.languageLevel = JavaVersion.VERSION_11
 minimallyCorrectDefaults.configureProject(project)
 
 dependencies {
-	testImplementation("junit:junit:4.13.2")
 	implementation("com.github.javaparser:javaparser-core:3.23.0")
 	api("com.google.code.findbugs:jsr305:3.0.2")
 	api("org.jetbrains:annotations:22.0.0")
@@ -50,6 +49,16 @@ dependencies {
 	testCompileOnly(lombok)
 	annotationProcessor(lombok)
 	testAnnotationProcessor(lombok)
+
+	testImplementation(platform("org.junit:junit-bom:5.8.1"))
+	testImplementation("org.junit.jupiter:junit-jupiter")
+	testImplementation("junit:junit:4.13.2")
+	testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test>().configureEach {
+	useJUnitPlatform()
 }
 
 tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
Migrates to JUnit 5 (using the vintage runner for now), for #7.

Demonstrates why this doesn't currently work.